### PR TITLE
Add articleBlurb to articles index

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -40,6 +40,9 @@ indices:
       description:
         select: head > meta[property="og:description"]
         value: attribute(el, "content")
+      articleBlurb:
+        select: head > meta[name="articleBlurb"]
+        value: attribute(el, "content")
       category:
         select: head > meta[name="category"]
         value: match(attribute(el, "content"), "(?:https:\/\/[^/]+)?(.+)")


### PR DESCRIPTION
Fix #69

Test URLs:
- Before: https://main--famous-smoke-cigaradvisor--hlxsites.hlx.page/cigaradvisor/
- After: https://issue-69--famous-smoke-cigaradvisor--hlxsites.hlx.page/cigaradvisor/
