### PR TITLE
Fix mobile header social icon color

### DIFF
--- a/cigaradvisor/blocks/header/header.css
+++ b/cigaradvisor/blocks/header/header.css
@@ -435,7 +435,7 @@
     color: var(--grey);
 }
 
-.header.block .mobile-nav .icon {
+.header.block .mobile-nav .mobile-primary-nav .icon {
     filter: var(--clr-filter-tan);
 }
 


### PR DESCRIPTION
Simple fix to change the color of the social media links inside of the mobile header from tan to black.

Test URLs:
- Before: https://main--famous-smoke-cigaradvisor--hlxsites.hlx.page/cigaradvisor/
- After: https://bug-social-icons--famous-smoke-cigaradvisor--hlxsites.hlx.page/cigaradvisor/
