### PR TITLE
issue-111 - Fix vimeo URLs under /video/x

### DIFF
--- a/cigaradvisor/blocks/video/video.js
+++ b/cigaradvisor/blocks/video/video.js
@@ -19,7 +19,7 @@ function embedYoutube(url, autoplay) {
 }
 
 function embedVimeo(url, autoplay) {
-  const [, video] = url.pathname.split('/');
+  const video = url.pathname.split('/').at(-1);
   const suffix = autoplay ? '?muted=1&autoplay=1' : '';
   return `<div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.25%;">
       <iframe src="https://player.vimeo.com/video/${video}${suffix}" 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--famous-smoke-cigaradvisor--hlxsites.hlx.page/cigaradvisor/drafts/tmaret/blocks/vimeo-oh-no
- After: https://issue-111--famous-smoke-cigaradvisor--hlxsites.hlx.page/cigaradvisor/drafts/tmaret/blocks/vimeo-oh-no
