### PR TITLE
Fix external footer URLs

### DIFF
--- a/cigaradvisor/blocks/footer/footer.js
+++ b/cigaradvisor/blocks/footer/footer.js
@@ -1,5 +1,6 @@
 import { getMetadata } from '../../scripts/aem.js';
 import { loadFragment } from '../fragment/fragment.js';
+import { isExternal } from '../../scripts/scripts.js';
 
 /**
  * loads and decorates the footer
@@ -40,6 +41,14 @@ export default async function decorate(block) {
     }
     footerNavContainer.append(footerNav);
   }
+
+  // Open external links in new tab
+  footerContent.querySelectorAll('a').forEach((a) => {
+    const href = a.getAttribute('href');
+    if (isExternal(href)) {
+      a.setAttribute('target', '_blank');
+    }
+  });
 
   block.innerHTML = footerContent.innerHTML;
   const footerHeading = document.createElement('H2');


### PR DESCRIPTION
Part of #131 

Test URLs:
- Before: https://main--famous-smoke-cigaradvisor--hlxsites.hlx.page/cigaradvisor
- After: https://bug-footer-url--famous-smoke-cigaradvisor--hlxsites.hlx.page/cigaradvisor
