### PR TITLE
Fix sitemap config

### DIFF
--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -16,6 +16,6 @@ sitemaps:
     lastmod: YYYY-MM-DD hh:mm:ss
   posts:
     origin: https://www.famous-smoke.com
-    source: /cigaradvisor/posts/query-index.json
+    source: /cigaradvisor/posts-index.json
     destination: /cigaradvisor/post-sitemap.xml
     lastmod: YYYY-MM-DD hh:mm:ss


### PR DESCRIPTION
Hopefully fix #222.
I'm not really able to test it without deploying...

Test URLs:
- Before: https://main--famous-smoke-cigaradvisor--hlxsites.hlx.page/cigaradvisor
- After: https://issue-222--famous-smoke-cigaradvisor--hlxsites.hlx.page/cigaradvisor
