### PR TITLE
Index cleanup & category sitemaps

### DIFF
--- a/cigaradvisor/scripts/scripts.js
+++ b/cigaradvisor/scripts/scripts.js
@@ -17,9 +17,9 @@ import { loadReturnToTop } from '../blocks/return-to-top/return-to-top.js';
 import addLinkingData from './linking-data.js';
 
 const LCP_BLOCKS = []; // add your LCP blocks to the list
-const AUTHOR_INDEX_PATH = '/cigaradvisor/author/query-index.json';
-const CATEGORY_INDEX_PATH = '/cigaradvisor/category/query-index.json';
-const ARTICLE_INDEX_PATH = '/cigaradvisor/posts-index.json';
+const AUTHOR_INDEX_PATH = '/cigaradvisor/author-index.json';
+const CATEGORY_INDEX_PATH = '/cigaradvisor/category-index.json';
+const ARTICLE_INDEX_PATH = '/cigaradvisor/article-index.json';
 const SEARCH_INDEX_PATH = '/cigaradvisor/search-index.json';
 
 /**

--- a/cigaradvisor/sitemap_index.xml
+++ b/cigaradvisor/sitemap_index.xml
@@ -9,6 +9,33 @@
     <loc>https://www.famous-smoke.com/cigaradvisor/author-sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.famous-smoke.com/cigaradvisor/post-sitemap.xml</loc>
+    <loc>https://www.famous-smoke.com/cigaradvisor/article-sitemap--buying-guides.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.famous-smoke.com/cigaradvisor/article-sitemap--cigar-humidification.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.famous-smoke.com/cigaradvisor/article-sitemap--cigar-lifestyle.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.famous-smoke.com/cigaradvisor/article-sitemap--cigar-makers.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.famous-smoke.com/cigaradvisor/article-sitemap--industry-news.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.famous-smoke.com/cigaradvisor/article-sitemap--cigar-reviews.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.famous-smoke.com/cigaradvisor/article-sitemap--cigars-101.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.famous-smoke.com/cigaradvisor/article-sitemap--cocktail.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.famous-smoke.com/cigaradvisor/article-sitemap--cuban-cigar-guides.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.famous-smoke.com/cigaradvisor/article-sitemap--uncategorized.xml</loc>
   </sitemap>
 </sitemapindex>

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -45,7 +45,7 @@ indices:
       - '**/cocktail/**'
       - '**/cuban-cigar-guides/**'
       - '**/uncategorized/**'
-    target: /cigaradvisor/pages-index.json
+    target: /cigaradvisor/page-index.json
     properties:
       title:
         select: head > meta[property="og:title"]
@@ -59,7 +59,7 @@ indices:
       lastModified:
         select: none
         value: parseTimestamp(headers["last-modified"], "ddd, DD MMM YYYY hh:mm:ss GMT")
-  category:
+  categories:
     include:
       - /cigaradvisor/buying-guides
       - /cigaradvisor/cigar-humidification
@@ -71,7 +71,7 @@ indices:
       - /cigaradvisor/cocktail
       - /cigaradvisor/cuban-cigar-guides
       - /cigaradvisor/uncategorized
-    target: /cigaradvisor/category/query-index.json
+    target: /cigaradvisor/category-index.json
     properties:
       title:
         select: head > title
@@ -91,7 +91,7 @@ indices:
   authors:
     include:
       - /cigaradvisor/author/*
-    target: /cigaradvisor/author/query-index.json
+    target: /cigaradvisor/author-index.json
     properties:
       title:
         select: head > title
@@ -126,7 +126,7 @@ indices:
       youtube:
         select: div.author-detail ul > li > a
         value: match(attribute(el, 'href'), '^(https?:\/\/(?:www\.)?youtube\.com\/.*)$')
-  posts:
+  articles:
     include:
       - /cigaradvisor/buying-guides/*
       - /cigaradvisor/cigar-humidification/*
@@ -138,7 +138,7 @@ indices:
       - /cigaradvisor/cocktail/*
       - /cigaradvisor/cuban-cigar-guides/*
       - /cigaradvisor/uncategorized/*
-    target: /cigaradvisor/posts-index.json
+    target: /cigaradvisor/article-index.json
     properties:
       title:
         select: head > meta[property="og:title"]
@@ -167,7 +167,7 @@ indices:
       category:
         select: none
         value: match(path, '(/cigaradvisor\/[^/]+)\/')
-  post-search:
+  article-search:
     include:
       - /cigaradvisor/buying-guides/*
       - /cigaradvisor/cigar-humidification/*

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -7,9 +7,9 @@ indices:
       - '**/drafts/**'
       - '**/images/**'
       - '**/icons/**'
-      - '/**/footer'
-      - '/**/nav'
-      - '/**/404'
+      - /cigaradvisor/footer
+      - /cigaradvisor/nav
+      - /cigaradvisor/404
     target: /cigaradvisor/query-index.json
     properties:
       title:
@@ -31,20 +31,20 @@ indices:
       - '**/drafts/**'
       - '**/images/**'
       - '**/icons/**'
-      - '/**/footer'
-      - '/**/nav'
-      - '/**/404'
-      - '**/author/**/*'
-      - '**/buying-guides/**'
-      - '**/cigar-humidification/**'
-      - '**/cigar-lifestyle/**'
-      - '**/cigar-makers/**'
-      - '**/industry-news/**'
-      - '**/cigar-reviews/**'
-      - '**/cigars-101/**'
-      - '**/cocktail/**'
-      - '**/cuban-cigar-guides/**'
-      - '**/uncategorized/**'
+      - /cigaradvisor/footer
+      - /cigaradvisor/nav
+      - /cigaradvisor/404
+      - /cigaradvisor/author/**
+      - /cigaradvisor/buying-guides/**
+      - /cigaradvisor/cigar-humidification/**
+      - /cigaradvisor/cigar-lifestyle/**
+      - /cigaradvisor/cigar-makers/**
+      - /cigaradvisor/industry-news/**
+      - /cigaradvisor/cigar-reviews/**
+      - /cigaradvisor/cigars-101/**
+      - /cigaradvisor/cocktail/**
+      - /cigaradvisor/cuban-cigar-guides/**
+      - /cigaradvisor/uncategorized/**
     target: /cigaradvisor/page-index.json
     properties:
       title:
@@ -71,6 +71,10 @@ indices:
       - /cigaradvisor/cocktail
       - /cigaradvisor/cuban-cigar-guides
       - /cigaradvisor/uncategorized
+    exclude:
+      - '**/drafts/**'
+      - '**/images/**'
+      - '**/icons/**'
     target: /cigaradvisor/category-index.json
     properties:
       title:
@@ -91,6 +95,10 @@ indices:
   authors:
     include:
       - /cigaradvisor/author/*
+    exclude:
+      - '**/drafts/**'
+      - '**/images/**'
+      - '**/icons/**'
     target: /cigaradvisor/author-index.json
     properties:
       title:
@@ -138,6 +146,10 @@ indices:
       - /cigaradvisor/cocktail/*
       - /cigaradvisor/cuban-cigar-guides/*
       - /cigaradvisor/uncategorized/*
+    exclude:
+      - '**/drafts/**'
+      - '**/images/**'
+      - '**/icons/**'
     target: /cigaradvisor/article-index.json
     properties:
       title:
@@ -179,6 +191,10 @@ indices:
       - /cigaradvisor/cocktail/*
       - /cigaradvisor/cuban-cigar-guides/*
       - /cigaradvisor/uncategorized/*
+    exclude:
+      - '**/drafts/**'
+      - '**/images/**'
+      - '**/icons/**'
     target: /cigaradvisor/search-index.json
     properties:
       title:

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -1,16 +1,19 @@
+.excludes: &excludes
+  - '**/drafts/**'
+  - '**/images/**'
+  - '**/icons/**'
+
 version: 1
 indices:
   default:
     include:
       - /**
     exclude:
-      - '**/drafts/**'
-      - '**/images/**'
-      - '**/icons/**'
+      - *excludes
       - /cigaradvisor/footer
       - /cigaradvisor/nav
       - /cigaradvisor/404
-    target: /cigaradvisor/query-index.json
+    target: /cigaradvisor/index/query-index.json
     properties:
       title:
         select: head > meta[property="og:title"]
@@ -28,9 +31,7 @@ indices:
     include:
       - /**
     exclude:
-      - '**/drafts/**'
-      - '**/images/**'
-      - '**/icons/**'
+      - *excludes
       - /cigaradvisor/footer
       - /cigaradvisor/nav
       - /cigaradvisor/404
@@ -45,7 +46,7 @@ indices:
       - /cigaradvisor/cocktail/**
       - /cigaradvisor/cuban-cigar-guides/**
       - /cigaradvisor/uncategorized/**
-    target: /cigaradvisor/page-index.json
+    target: /cigaradvisor/index/page-index.json
     properties:
       title:
         select: head > meta[property="og:title"]
@@ -71,11 +72,8 @@ indices:
       - /cigaradvisor/cocktail
       - /cigaradvisor/cuban-cigar-guides
       - /cigaradvisor/uncategorized
-    exclude:
-      - '**/drafts/**'
-      - '**/images/**'
-      - '**/icons/**'
-    target: /cigaradvisor/category-index.json
+    exclude: *excludes
+    target: /cigaradvisor/index/category-index.json
     properties:
       title:
         select: head > title
@@ -95,11 +93,8 @@ indices:
   authors:
     include:
       - /cigaradvisor/author/*
-    exclude:
-      - '**/drafts/**'
-      - '**/images/**'
-      - '**/icons/**'
-    target: /cigaradvisor/author-index.json
+    exclude: *excludes
+    target: /cigaradvisor/index/author-index.json
     properties:
       title:
         select: head > title
@@ -146,12 +141,9 @@ indices:
       - /cigaradvisor/cocktail/*
       - /cigaradvisor/cuban-cigar-guides/*
       - /cigaradvisor/uncategorized/*
-    exclude:
-      - '**/drafts/**'
-      - '**/images/**'
-      - '**/icons/**'
-    target: /cigaradvisor/article-index.json
-    properties:
+    exclude: *excludes
+    target: /cigaradvisor/index/article-index.json
+    properties: &articles_properties
       title:
         select: head > meta[property="og:title"]
         value: attribute(el, "content")
@@ -191,11 +183,8 @@ indices:
       - /cigaradvisor/cocktail/*
       - /cigaradvisor/cuban-cigar-guides/*
       - /cigaradvisor/uncategorized/*
-    exclude:
-      - '**/drafts/**'
-      - '**/images/**'
-      - '**/icons/**'
-    target: /cigaradvisor/search-index.json
+    exclude: *excludes
+    target: /cigaradvisor/index/search-index.json
     properties:
       title:
         select: head > meta[property="og:title"]
@@ -209,3 +198,63 @@ indices:
       text:
         select: main > div p
         value: words(textContent(el), 0, 5000)
+  buying-guides:
+    include:
+      - /cigaradvisor/buying-guides/*
+    exclude: *excludes
+    target: /cigaradvisor/index/article-index--buying-guides.json
+    properties: *articles_properties
+  cigar-humidification:
+    include:
+      - /cigaradvisor/cigar-humidification/*
+    exclude: *excludes
+    target: /cigaradvisor/index/article-index--cigar-humidification.json
+    properties: *articles_properties
+  cigar-lifestyle:
+    include:
+      - /cigaradvisor/cigar-lifestyle/*
+    exclude: *excludes
+    target: /cigaradvisor/index/article-index--cigar-lifestyle.json
+    properties: *articles_properties
+  cigar-makers:
+    include:
+      - /cigaradvisor/cigar-makers/*
+    exclude: *excludes
+    target: /cigaradvisor/index/article-index--cigar-makers.json
+    properties: *articles_properties
+  industry-news:
+    include:
+      - /cigaradvisor/industry-news/*
+    exclude: *excludes
+    target: /cigaradvisor/index/article-index--industry-news.json
+    properties: *articles_properties
+  cigar-reviews:
+    include:
+      - /cigaradvisor/cigar-reviews/*
+    exclude: *excludes
+    target: /cigaradvisor/index/article-index--cigar-reviews.json
+    properties: *articles_properties
+  cigar-101:
+    include:
+      - /cigaradvisor/cigars-101/*
+    exclude: *excludes
+    target: /cigaradvisor/index/article-index--cigars-101.json
+    properties: *articles_properties
+  cocktail:
+    include:
+      - /cigaradvisor/cocktail/*
+    exclude: *excludes
+    target: /cigaradvisor/index/article-index--cocktail.json
+    properties: *articles_properties
+  cuban-cigar-guides:
+    include:
+      - /cigaradvisor/cuban-cigar-guides/*
+    exclude: *excludes
+    target: /cigaradvisor/index/article-index--cuban-cigar-guides.json
+    properties: *articles_properties
+  uncategorized:
+    include:
+      - /cigaradvisor/uncategorized/*
+    exclude: *excludes
+    target: /cigaradvisor/index/article-index--uncategorized.json
+    properties: *articles_properties

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -1,21 +1,21 @@
 sitemaps:
   pages:
     origin: https://www.famous-smoke.com
-    source: /cigaradvisor/pages-index.json
+    source: /cigaradvisor/page-index.json
     destination: /cigaradvisor/page-sitemap.xml
     lastmod: YYYY-MM-DD hh:mm:ss
   category:
     origin: https://www.famous-smoke.com
-    source: /cigaradvisor/category/query-index.json
+    source: /cigaradvisor/category-index.json
     destination: /cigaradvisor/category-sitemap.xml
     lastmod: YYYY-MM-DD hh:mm:ss
   author:
     origin: https://www.famous-smoke.com
-    source: /cigaradvisor/author/query-index.json
+    source: /cigaradvisor/author-index.json
     destination: /cigaradvisor/author-sitemap.xml
     lastmod: YYYY-MM-DD hh:mm:ss
-  posts:
+  articles:
     origin: https://www.famous-smoke.com
-    source: /cigaradvisor/posts/query-index.json
+    source: /cigaradvisor/article-index.json
     destination: /cigaradvisor/post-sitemap.xml
     lastmod: YYYY-MM-DD hh:mm:ss

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -1,21 +1,67 @@
 sitemaps:
   pages:
     origin: https://www.famous-smoke.com
-    source: /cigaradvisor/page-index.json
+    source: /cigaradvisor/index/page-index.json
     destination: /cigaradvisor/page-sitemap.xml
     lastmod: YYYY-MM-DD hh:mm:ss
   category:
     origin: https://www.famous-smoke.com
-    source: /cigaradvisor/category-index.json
+    source: /cigaradvisor/index/category-index.json
     destination: /cigaradvisor/category-sitemap.xml
     lastmod: YYYY-MM-DD hh:mm:ss
   author:
     origin: https://www.famous-smoke.com
-    source: /cigaradvisor/author-index.json
+    source: /cigaradvisor/index/author-index.json
     destination: /cigaradvisor/author-sitemap.xml
     lastmod: YYYY-MM-DD hh:mm:ss
   articles:
-    origin: https://www.famous-smoke.com
-    source: /cigaradvisor/article-index.json
-    destination: /cigaradvisor/post-sitemap.xml
-    lastmod: YYYY-MM-DD hh:mm:ss
+    buying-guides:
+      origin: https://www.famous-smoke.com
+      source: /cigaradvisor/index/article-index--buying-guide.json
+      destination: /cigaradvisor/article-sitemap--buying-guides.xml
+      lastmod: YYYY-MM-DD hh:mm:ss
+    cigar-humidification:
+      origin: https://www.famous-smoke.com
+      source: /cigaradvisor/index/article-index--cigar-humidification.json
+      destination: /cigaradvisor/article-sitemap--cigar-humidification.xml
+      lastmod: YYYY-MM-DD hh:mm:ss
+    cigar-lifestyle:
+      origin: https://www.famous-smoke.com
+      source: /cigaradvisor/index/article-index--cigar-lifestyle.json
+      destination: /cigaradvisor/article-sitemap--cigar-lifestyle.xml
+      lastmod: YYYY-MM-DD hh:mm:ss
+    cigar-makers:
+      origin: https://www.famous-smoke.com
+      source: /cigaradvisor/index/article-index--cigar-makers.json
+      destination: /cigaradvisor/article-sitemap--cigar-makers.xml
+      lastmod: YYYY-MM-DD hh:mm:ss
+    industry-news:
+      origin: https://www.famous-smoke.com
+      source: /cigaradvisor/index/article-index--industry-news.json
+      destination: /cigaradvisor/article-sitemap--industry-news.xml
+      lastmod: YYYY-MM-DD hh:mm:ss
+    cigar-reviews:
+      origin: https://www.famous-smoke.com
+      source: /cigaradvisor/index/article-index--cigar-reviews.json
+      destination: /cigaradvisor/article-sitemap--cigar-reviews.xml
+      lastmod: YYYY-MM-DD hh:mm:ss
+    cigars-101:
+      origin: https://www.famous-smoke.com
+      source: /cigaradvisor/index/article-index--cigars-101.json
+      destination: /cigaradvisor/article-sitemap--cigars-101.xml
+      lastmod: YYYY-MM-DD hh:mm:ss
+    cocktail:
+      origin: https://www.famous-smoke.com
+      source: /cigaradvisor/index/article-index--cocktail.json
+      destination: /cigaradvisor/article-sitemap--cocktail.xml
+      lastmod: YYYY-MM-DD hh:mm:ss
+    cuban-cigar-guides:
+      origin: https://www.famous-smoke.com
+      source: /cigaradvisor/index/article-index--cuban-cigar-guides.json
+      destination: /cigaradvisor/article-sitemap--cuban-cigar-guides.xml
+      lastmod: YYYY-MM-DD hh:mm:ss
+    uncategorized:
+      origin: https://www.famous-smoke.com
+      source: /cigaradvisor/index/article-index--uncategorized.json
+      destination: /cigaradvisor/article-sitemap--uncategorized.xml
+      lastmod: YYYY-MM-DD hh:mm:ss


### PR DESCRIPTION
Fix #222 

Test URLs:
- Before: https://main--famous-smoke-cigaradvisor--hlxsites.hlx.page/cigaradvisor
- After: https://index-cleanup--famous-smoke-cigaradvisor--hlxsites.hlx.page/cigaradvisor

Changes:
- moved all indices to `index/<name>-index[--<category>].json`
- renamed `posts` references to `articles`
- improved index path naming and added default excludes to all indices
- added an additional index and sitemap for each category
- the combined articles index is still in place for faster lookup times