### PR TITLE
Fix typo in sitemap config

### DIFF
--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -16,7 +16,7 @@ sitemaps:
     lastmod: YYYY-MM-DD hh:mm:ss
   buying-guides:
     origin: https://www.famous-smoke.com
-    source: /cigaradvisor/index/article-index-buying-guide.json
+    source: /cigaradvisor/index/article-index-buying-guides.json
     destination: /cigaradvisor/article-sitemap-buying-guides.xml
     lastmod: YYYY-MM-DD hh:mm:ss
   cigar-humidification:


### PR DESCRIPTION
Part of #222 

Test URLs:
- Before: https://main--famous-smoke-cigaradvisor--hlxsites.hlx.page/cigaradvisor
- After: https://bug-sitemap-typo--famous-smoke-cigaradvisor--hlxsites.hlx.page/cigaradvisor
