### PR TITLE
Add LCP blocks

### DIFF
--- a/cigaradvisor/scripts/scripts.js
+++ b/cigaradvisor/scripts/scripts.js
@@ -16,7 +16,7 @@ import {
 import { loadReturnToTop } from '../blocks/return-to-top/return-to-top.js';
 import addLinkingData from './linking-data.js';
 
-const LCP_BLOCKS = []; // add your LCP blocks to the list
+const LCP_BLOCKS = ['hero', 'articleheader'];
 const AUTHOR_INDEX_PATH = '/cigaradvisor/index/author-index.json';
 const CATEGORY_INDEX_PATH = '/cigaradvisor/index/category-index.json';
 const ARTICLE_INDEX_PATH = '/cigaradvisor/index/article-index.json';


### PR DESCRIPTION
Even though I can't reproduce #234 anymore, it's still a good idea to add our hero-like blocks to the LCP block list.

Test URLs:
- Before: https://main--famous-smoke-cigaradvisor--hlxsites.hlx.page/cigaradvisor
- After: https://lhs-lcp-blocks--famous-smoke-cigaradvisor--hlxsites.hlx.page/cigaradvisor
