### PR TITLE
Fix captioned image links

### DIFF
--- a/cigaradvisor/blocks/captioned-image/captioned-image.js
+++ b/cigaradvisor/blocks/captioned-image/captioned-image.js
@@ -18,7 +18,7 @@ export default async function decorate(block) {
 
   // Does the image link?
   const keys = Object.keys(config);
-  if (keys.link) {
+  if (config.link) {
     const idx = keys.indexOf('link');
     const a = block.querySelector(`:scope > div:nth-of-type(${idx + 1}) > div:nth-of-type(2) a`);
     a.append(picture);


### PR DESCRIPTION
Fix #279

Test URLs:
- Before: https://main--famous-smoke-cigaradvisor--hlxsites.hlx.page/cigaradvisor
- After: https://bug-279--famous-smoke-cigaradvisor--hlxsites.hlx.page/cigaradvisor
