### PR TITLE
Allow numbers in search. Add Prettier settings file.

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "printWidth": 800
+}

--- a/cigaradvisor/blocks/search-results/search-results.js
+++ b/cigaradvisor/blocks/search-results/search-results.js
@@ -8,7 +8,7 @@ async function handleSearch(searchValue, block, limit) {
   const wrapper = block.querySelector('.article-teaser-wrapper');
   const searchSummary = document.createElement('p');
   searchSummary.classList.add('search-summary');
-  if (searchValue.length < 3 || !searchValue.match(/[a-z]/i)) {
+  if (searchValue.length < 3 || !searchValue.match(/[a-z0-9]/i)) {
     searchSummary.innerHTML = 'Please enter at least three (3) characters to search.';
     wrapper.replaceChildren(searchSummary);
     return;
@@ -23,7 +23,7 @@ async function handleSearch(searchValue, block, limit) {
     if (results.length === 0) {
       const noResults = document.createElement('p');
       noResults.classList.add('no-results');
-      noResults.textContent = 'Sorry, we couldn\'t find the information you requested!';
+      noResults.textContent = "Sorry, we couldn't find the information you requested!";
       wrapper.replaceChildren(searchSummary);
       wrapper.append(noResults);
       block.classList.remove('loading');


### PR DESCRIPTION
Fix #314

Test URLs:
- Before: https://main--famous-smoke-cigaradvisor--hlxsites.hlx.page/cigaradvisor/search
- After: https://314-fix-search-by-numbers--famous-smoke-cigaradvisor--hlxsites.hlx.page/cigaradvisor/search

### Changes

- Enable search by numbers by altering regex.
- Add Prettier settings file.